### PR TITLE
feature(get): get doc from cache if flagged and exist #3

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -2,6 +2,6 @@
   "imports": {
     "asserts": "https://deno.land/std@0.125.0/testing/asserts.ts",
     "ramda": "https://cdn.skypack.dev/ramda@0.28.0",
-    "crocks": "https://cdn.skypack.dev/crocks@0.12.1"
+    "crocks": "https://cdn.skypack.dev/crocks@0.12.3"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -2,6 +2,7 @@
   "imports": {
     "asserts": "https://deno.land/std@0.125.0/testing/asserts.ts",
     "ramda": "https://cdn.skypack.dev/ramda@0.28.0",
-    "crocks": "https://cdn.skypack.dev/crocks@0.12.3"
+    "crocks": "https://cdn.skypack.dev/crocks@0.12.3",
+    "zod": "https://deno.land/x/zod@v3.11.6/mod.ts"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "rollup -c"
   },
   "dependencies": {
+    "crocks": "^0.12.4",
     "ramda": "^0.28.0"
   }
 }

--- a/src/actions/get.ts
+++ b/src/actions/get.ts
@@ -1,0 +1,28 @@
+import { Async, ReaderT } from "crocks";
+
+const { of, ask, lift } = ReaderT(Async);
+
+interface H {
+  data: {
+    get: (id: string) => typeof Async;
+  };
+  cache: {
+    get: (id: string) => typeof Async;
+  };
+}
+
+interface config {
+  cache: boolean;
+}
+
+const doGet = (hyper: H, id: string) =>
+  ({ cache }: config) =>
+    cache
+      ? hyper.cache.get(id)
+        .bichain(hyper.data.get, Async.Resolved)
+      : hyper.data.get(id);
+
+export const get = (hyper: H) =>
+  (id: string) =>
+    of(id)
+      .chain((id: string) => ask(doGet(hyper, id)).chain(lift));

--- a/src/actions/get_test.ts
+++ b/src/actions/get_test.ts
@@ -1,8 +1,13 @@
 import { assertEquals } from "asserts";
 import { get } from "./get.ts";
 import { Async } from "crocks";
+import { z } from "zod";
 
 const getFn = () => Async.Resolved({ _id: "1", title: "doc" });
+
+const schema = z.object({
+  _id: z.string(),
+});
 
 const hyperAsync = {
   data: {
@@ -14,13 +19,13 @@ const hyperAsync = {
 };
 
 Deno.test("get document by id from cache", async () => {
-  const result = await get(hyperAsync)("1").runWith({ cache: true })
+  const result = await get(hyperAsync)("1").runWith({ cache: true, schema })
     .toPromise();
   assertEquals(result._id, "1");
 });
 
 Deno.test("get document by id no cache", async () => {
-  const result = await get(hyperAsync)("1").runWith({ cache: false })
+  const result = await get(hyperAsync)("1").runWith({ cache: false, schema })
     .toPromise();
   assertEquals(result._id, "1");
 });
@@ -35,7 +40,7 @@ Deno.test("get document by id with cache but not found", async () => {
     },
   };
 
-  const result = await get(hyperAsync2)("1").runWith({ cache: true })
+  const result = await get(hyperAsync2)("1").runWith({ cache: true, schema })
     .toPromise();
   assertEquals(result._id, "1");
 });
@@ -50,7 +55,7 @@ Deno.test("get document by id not found", async () => {
     },
   };
 
-  const result = await get(hyperAsync2)("1").runWith({ cache: true })
+  const result = await get(hyperAsync2)("1").runWith({ cache: true, schema })
     .toPromise().catch((e: unknown) => e);
   assertEquals(result.ok, false);
 });

--- a/src/actions/get_test.ts
+++ b/src/actions/get_test.ts
@@ -1,0 +1,56 @@
+import { assertEquals } from "asserts";
+import { get } from "./get.ts";
+import { Async } from "crocks";
+
+const getFn = () => Async.Resolved({ _id: "1", title: "doc" });
+
+const hyperAsync = {
+  data: {
+    get: getFn,
+  },
+  cache: {
+    get: getFn,
+  },
+};
+
+Deno.test("get document by id from cache", async () => {
+  const result = await get(hyperAsync)("1").runWith({ cache: true })
+    .toPromise();
+  assertEquals(result._id, "1");
+});
+
+Deno.test("get document by id no cache", async () => {
+  const result = await get(hyperAsync)("1").runWith({ cache: false })
+    .toPromise();
+  assertEquals(result._id, "1");
+});
+
+Deno.test("get document by id with cache but not found", async () => {
+  const hyperAsync2 = {
+    data: {
+      get: getFn,
+    },
+    cache: {
+      get: () => Async.Rejected({ ok: false }),
+    },
+  };
+
+  const result = await get(hyperAsync2)("1").runWith({ cache: true })
+    .toPromise();
+  assertEquals(result._id, "1");
+});
+
+Deno.test("get document by id not found", async () => {
+  const hyperAsync2 = {
+    data: {
+      get: () => Async.Rejected({ ok: false }),
+    },
+    cache: {
+      get: () => Async.Rejected({ ok: false }),
+    },
+  };
+
+  const result = await get(hyperAsync2)("1").runWith({ cache: true })
+    .toPromise().catch((e: unknown) => e);
+  assertEquals(result.ok, false);
+});

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,14 +1,18 @@
 import { mergeDeepRight } from "ramda";
+import { asyncify } from "./asyncify.ts";
+import { get } from "./actions/get.ts";
 
-export const model = (hyper: unknown) =>
-  mergeDeepRight(
+export const model = (hyper: unknown) => {
+  const hyperAsync = asyncify(hyper);
+  return mergeDeepRight(
     hyper,
     {
       ext: {
-        model(/* config */) {
+        model(config: unknown) {
           return Object.freeze({
             upsert: noop,
-            get: noop,
+            get: (id: string) =>
+              get(hyperAsync)(id).runWith(config).toPromise(),
             remove: noop,
             query: noop,
             search: noop,
@@ -21,6 +25,7 @@ export const model = (hyper: unknown) =>
       },
     },
   );
+};
 
 function noop() {
   return Promise.resolve({ ok: false, msg: "Not Implemented!" });

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "asserts";
 import { model } from "./mod.ts";
+import { z } from "zod";
+
+const schema = z.object({
+  _id: z.string(),
+});
 
 Deno.test("ok", () => {
   assertEquals(true, true);
@@ -10,7 +15,7 @@ const hyper = model({
     get: () => Promise.resolve({ _id: "1" }),
   },
 });
-const profiles = hyper.ext.model({ cache: false });
+const profiles = hyper.ext.model({ cache: false, schema });
 
 Deno.test("upsert document successfully", async () => {
   const result = await profiles.upsert("1", { username: "rakis" });

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -5,8 +5,12 @@ Deno.test("ok", () => {
   assertEquals(true, true);
 });
 
-const hyper = model({});
-const profiles = hyper.ext.model();
+const hyper = model({
+  data: {
+    get: () => Promise.resolve({ _id: "1" }),
+  },
+});
+const profiles = hyper.ext.model({ cache: false });
 
 Deno.test("upsert document successfully", async () => {
   const result = await profiles.upsert("1", { username: "rakis" });
@@ -16,8 +20,8 @@ Deno.test("upsert document successfully", async () => {
 
 Deno.test("get document successfully", async () => {
   const result = await profiles.get("1");
-  assertEquals(result.ok, false);
-  assertEquals(result.msg, "Not Implemented!");
+  console.log(result);
+  assertEquals(result._id, "1");
 });
 
 Deno.test("remove document successfully", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+crocks@^0.12.4:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.12.4.tgz#b4a4512f64e90c42d31375e1a2902a0f9d4b4916"
+  integrity sha512-paln6xJUrR9e/OWMFsyTi4dLyr+q99C5f7PQbGgSDHtwsfW0sCNZvnpHzvniI2dAE0uoBgeIP1Ukmme8Z0HxxA==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"


### PR DESCRIPTION
First pass at `model.get` in the issue are sequence diagrams documenting the scenarios, I don't think any modes apply for this feature.