### PR TITLE
Twilson63/feature core model data service plus validation

### DIFF
--- a/src/actions/get.ts
+++ b/src/actions/get.ts
@@ -1,4 +1,6 @@
 import { Async, ReaderT } from "crocks";
+import type { Config } from "../types.ts";
+
 //import { z } from "zod";
 
 const { of, ask, lift } = ReaderT(Async);
@@ -12,11 +14,6 @@ interface H {
   };
 }
 
-interface config {
-  cache: boolean;
-  schema: unknown;
-}
-
 // @ts-ignore allow any type
 const validate = (schema) =>
   (doc: unknown) => {
@@ -26,13 +23,11 @@ const validate = (schema) =>
   };
 
 const doGet = (hyper: H, id: string) =>
-  ({ cache, schema }: config) =>
-    cache
-      ? hyper.cache.get(id)
-        .bichain(hyper.data.get, Async.Resolved)
+  ({ schema }: Config) =>
+    schema
+      ? hyper.data.get(id)
         .chain(validate(schema))
-      : hyper.data.get(id)
-        .chain(validate(schema));
+      : hyper.data.get(id);
 
 export const get = (hyper: H) =>
   (id: string) =>

--- a/src/actions/get_test.ts
+++ b/src/actions/get_test.ts
@@ -19,13 +19,13 @@ const hyperAsync = {
 };
 
 Deno.test("get document by id from cache", async () => {
-  const result = await get(hyperAsync)("1").runWith({ cache: true, schema })
+  const result = await get(hyperAsync)("1").runWith({ schema })
     .toPromise();
   assertEquals(result._id, "1");
 });
 
-Deno.test("get document by id no cache", async () => {
-  const result = await get(hyperAsync)("1").runWith({ cache: false, schema })
+Deno.test("get document by id no schema", async () => {
+  const result = await get(hyperAsync)("1").runWith({})
     .toPromise();
   assertEquals(result._id, "1");
 });

--- a/src/actions/query.ts
+++ b/src/actions/query.ts
@@ -1,0 +1,20 @@
+import { Async, ReaderT } from "crocks";
+//import type { Config } from "../types.ts";
+
+//import { z } from "zod";
+interface H {
+  data: {
+    query: (selector: unknown, options: unknown) => typeof Async;
+  };
+}
+
+const { of, ask, lift } = ReaderT(Async);
+
+const doQuery = (hyper: H, selector: unknown, options?: unknown) =>
+  (/* env: Config */) => hyper.data.query(selector, options);
+
+export const query = (hyper: H) =>
+  (selector: unknown, options?: unknown) =>
+    of().chain(
+      () => ask(doQuery(hyper, selector, options)),
+    ).chain(lift);

--- a/src/actions/query_test.ts
+++ b/src/actions/query_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "asserts";
+import { query } from "./query.ts";
+import { Async } from "crocks";
+
+const hyperAsync = {
+  data: {
+    query: () =>
+      Async.Resolved({
+        ok: true,
+        docs: [
+          { _id: "1", username: "rakis", type: "profile" },
+          { _id: "2", username: "twilson63", type: "profile" },
+        ],
+      }),
+  },
+};
+
+Deno.test("query profiles", async () => {
+  const result = await query(hyperAsync)({ type: "profile" }).runWith({
+    name: "profile",
+  }).toPromise();
+  assertEquals(result.docs.length, 2);
+});

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -49,3 +49,19 @@ export const remove = (hyper: H) =>
       .chain(removeFromSearch)
       .chain(removeFromCache)
       .chain(removeFromData);
+
+
+// first based on env via ask, we need to get all resources and put them in a context object
+// this context object will contain the context that is required to work through the pipeline
+/*
+ask(env => of(env)
+  .map(buildContext)
+  .chain(get)
+  .chain(remove)
+  .chain(dec)
+  .bichain(
+    ifElse(isAtomic, rollback, compose(of, prop('result'))),
+    ctx => of(ctx).chain(notify).map(prop('result'))
+  )
+).chain(lift)
+*/

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -1,7 +1,10 @@
 import { Async, ReaderT } from "crocks";
+import { __, assoc, compose, ifElse, isNil, path } from "ramda";
+import type { Config } from "../types.ts";
 
 interface H {
   data: {
+    get: (id: string) => typeof Async;
     remove: (id: string) => typeof Async;
   };
   cache: {
@@ -12,21 +15,18 @@ interface H {
   };
 }
 
-interface config {
-  cache: boolean;
-  schema: unknown;
-}
-
 interface Context {
   hyper: H;
   id: string;
+  env?: Config;
+  doc?: unknown;
 }
 
 const { of, ask, lift } = ReaderT(Async);
 
 // first pass does not address any modes atomic vers non-atomic
 // it simply tries to delete everything if they exist or not
-
+/*
 const removeFromSearch = ({ hyper, id }: Context) =>
   ask(() =>
     hyper.search.remove(id)
@@ -38,18 +38,48 @@ const removeFromCache = ({ hyper, id }: Context) =>
     hyper.cache.remove(id)
       .coalesce(() => ({ hyper, id }), () => ({ hyper, id }))
   ).chain(lift);
-
-const removeFromData = ({ hyper, id }: Context) =>
-  ask(() => hyper.data.remove(id)).chain(lift);
+*/
+const getFromData = (ctx: Context) =>
+  ctx.hyper.data.get(ctx.id).map(assoc("doc", __, ctx));
+const removeFromData = ({ hyper, id }: Context) => hyper.data.remove(id);
+const validateDocument = ifElse(
+  compose(isNil, path(["env", "schema"])),
+  Async.Resolved,
+  (ctx: Context) => {
+    // @ts-ignore safeParse invoke
+    const validate = Async.fromPromise(ctx.env.schema.spa.bind(ctx.env.schema));
+    return validate(ctx.doc)
+      .bichain(
+        // @ts-ignore zod error
+        (e) => {
+          console.log(e);
+          return Async.Rejected({
+            msg: "ERROR: could not parse",
+            issues: e.issues,
+          });
+        },
+        // @ts-ignore zod success
+        ({ success, error }) =>
+          success ? Async.Resolved(ctx) : Async.Rejected({
+            msg: "ERROR: could not remove, document invalid",
+            issues: error.issues,
+          }),
+      );
+  },
+);
 
 // TODO: need to handle modes, atomic and non-atomic
 export const remove = (hyper: H) =>
   (id: string) =>
     of({ hyper, id })
-      .chain(removeFromSearch)
-      .chain(removeFromCache)
-      .chain(removeFromData);
-
+      .chain((ctx: Context) =>
+        ask((env: Config) =>
+          Async.of({ env, ...ctx })
+            .chain(getFromData)
+            .chain(validateDocument)
+            .chain(removeFromData)
+        ).chain(lift)
+      );
 
 // first based on env via ask, we need to get all resources and put them in a context object
 // this context object will contain the context that is required to work through the pipeline

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -54,6 +54,7 @@ const validateDocument = ifElse(
         (e) => {
           console.log(e);
           return Async.Rejected({
+            ok: false,
             msg: "ERROR: could not parse",
             issues: e.issues,
           });
@@ -61,6 +62,7 @@ const validateDocument = ifElse(
         // @ts-ignore zod success
         ({ success, error }) =>
           success ? Async.Resolved(ctx) : Async.Rejected({
+            ok: false,
             msg: "ERROR: could not remove, document invalid",
             issues: error.issues,
           }),

--- a/src/actions/remove.ts
+++ b/src/actions/remove.ts
@@ -1,0 +1,51 @@
+import { Async, ReaderT } from "crocks";
+
+interface H {
+  data: {
+    remove: (id: string) => typeof Async;
+  };
+  cache: {
+    remove: (id: string) => typeof Async;
+  };
+  search: {
+    remove: (id: string) => typeof Async;
+  };
+}
+
+interface config {
+  cache: boolean;
+  schema: unknown;
+}
+
+interface Context {
+  hyper: H;
+  id: string;
+}
+
+const { of, ask, lift } = ReaderT(Async);
+
+// first pass does not address any modes atomic vers non-atomic
+// it simply tries to delete everything if they exist or not
+
+const removeFromSearch = ({ hyper, id }: Context) =>
+  ask(() =>
+    hyper.search.remove(id)
+      .coalesce(() => ({ hyper, id }), () => ({ hyper, id }))
+  ).chain(lift);
+
+const removeFromCache = ({ hyper, id }: Context) =>
+  ask(() =>
+    hyper.cache.remove(id)
+      .coalesce(() => ({ hyper, id }), () => ({ hyper, id }))
+  ).chain(lift);
+
+const removeFromData = ({ hyper, id }: Context) =>
+  ask(() => hyper.data.remove(id)).chain(lift);
+
+// TODO: need to handle modes, atomic and non-atomic
+export const remove = (hyper: H) =>
+  (id: string) =>
+    of({ hyper, id })
+      .chain(removeFromSearch)
+      .chain(removeFromCache)
+      .chain(removeFromData);

--- a/src/actions/remove_test.ts
+++ b/src/actions/remove_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "asserts";
 import { remove } from "./remove.ts";
+import { always } from 'ramda';
 import { Async } from "crocks";
 import { z } from "zod";
 
@@ -7,16 +8,21 @@ const removeFn = () => Async.Resolved({ ok: true });
 
 const schema = z.object({
   _id: z.string(),
+  type: z.string(),
+  name: z.string()
 });
 
 const hyperAsync = {
   data: {
+    get: always({_id: 'contact-1', type: 'contact', name: 'foo'}),
     remove: removeFn,
   },
   cache: {
+    get: always({_id: 'contact-1', type: 'contact', name: 'foo'}),
     remove: removeFn,
   },
   search: {
+    get: always({id: 'contact-1', type: 'contact', name: 'foo'}),
     remove: removeFn,
   },
 };

--- a/src/actions/remove_test.ts
+++ b/src/actions/remove_test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from "asserts";
+import { remove } from "./remove.ts";
+import { Async } from "crocks";
+import { z } from "zod";
+
+const removeFn = () => Async.Resolved({ ok: true });
+
+const schema = z.object({
+  _id: z.string(),
+});
+
+const hyperAsync = {
+  data: {
+    remove: removeFn,
+  },
+  cache: {
+    remove: removeFn,
+  },
+  search: {
+    remove: removeFn,
+  },
+};
+
+Deno.test("remove document", async () => {
+  const result = await remove(hyperAsync)("1").runWith({
+    search: true,
+    cache: true,
+    schema,
+  })
+    .toPromise();
+  assertEquals(result.ok, true);
+});

--- a/src/actions/remove_test.ts
+++ b/src/actions/remove_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "asserts";
 import { remove } from "./remove.ts";
-import { always } from 'ramda';
+import { always } from "ramda";
 import { Async } from "crocks";
 import { z } from "zod";
 
@@ -9,20 +9,26 @@ const removeFn = () => Async.Resolved({ ok: true });
 const schema = z.object({
   _id: z.string(),
   type: z.string(),
-  name: z.string()
+  name: z.string(),
 });
 
 const hyperAsync = {
   data: {
-    get: always({_id: 'contact-1', type: 'contact', name: 'foo'}),
+    get: always(
+      Async.Resolved({ _id: "contact-1", type: "contact", name: "foo" }),
+    ),
     remove: removeFn,
   },
   cache: {
-    get: always({_id: 'contact-1', type: 'contact', name: 'foo'}),
+    get: always(
+      Async.Resolved({ _id: "contact-1", type: "contact", name: "foo" }),
+    ),
     remove: removeFn,
   },
   search: {
-    get: always({id: 'contact-1', type: 'contact', name: 'foo'}),
+    get: always(
+      Async.Resolved({ id: "contact-1", type: "contact", name: "foo" }),
+    ),
     remove: removeFn,
   },
 };
@@ -34,5 +40,6 @@ Deno.test("remove document", async () => {
     schema,
   })
     .toPromise();
+  console.log(result);
   assertEquals(result.ok, true);
 });

--- a/src/actions/remove_test.ts
+++ b/src/actions/remove_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "asserts";
 import { remove } from "./remove.ts";
-import { always } from "ramda";
+import { always, identity } from "ramda";
 import { Async } from "crocks";
 import { z } from "zod";
 
@@ -33,13 +33,51 @@ const hyperAsync = {
   },
 };
 
-Deno.test("remove document", async () => {
+Deno.test("remove document successfully", async () => {
   const result = await remove(hyperAsync)("1").runWith({
     search: true,
     cache: true,
     schema,
   })
     .toPromise();
-  console.log(result);
   assertEquals(result.ok, true);
+});
+
+Deno.test("remove document without schema configured", async () => {
+  const result = await remove(hyperAsync)("1").runWith({}).toPromise();
+  assertEquals(result.ok, true);
+});
+
+Deno.test("remove document invalid schema", async () => {
+  const result = await remove(hyperAsync)("1").runWith({
+    schema: z.string(),
+  }).toPromise().catch(identity);
+  assertEquals(result.ok, false);
+});
+
+Deno.test("remove document that is not found", async () => {
+  const hyper = {
+    data: {
+      get: always(
+        Async.Rejected({ ok: false, msg: "Not Found!" }),
+      ),
+      remove: removeFn,
+    },
+    cache: {
+      get: always(
+        Async.Resolved({ _id: "contact-1", type: "contact", name: "foo" }),
+      ),
+      remove: removeFn,
+    },
+    search: {
+      get: always(
+        Async.Resolved({ id: "contact-1", type: "contact", name: "foo" }),
+      ),
+      remove: removeFn,
+    },
+  };
+  const result = await remove(hyper)("1").runWith({}).toPromise().catch(
+    identity,
+  );
+  assertEquals(result.ok, false);
 });

--- a/src/actions/upsert.ts
+++ b/src/actions/upsert.ts
@@ -34,8 +34,7 @@ const doUpsert = (hyper: H, doc: unknown) =>
         compose(hyper.data.get, prop("_id"))(doc)
           .bichain(
             () => hyper.data.add(doc),
-            (old: unknown) =>
-              hyper.data.update(prop("_id", old), mergeRight(old, doc)),
+            (old: unknown) => hyper.data.update(prop("_id", old), doc),
           )
       );
 

--- a/src/actions/upsert.ts
+++ b/src/actions/upsert.ts
@@ -1,0 +1,45 @@
+import { Async, ReaderT } from "crocks";
+import { compose, ifElse, isNil, mergeRight, prop } from "ramda";
+import type { Config } from "../types.ts";
+
+//import { z } from "zod";
+interface H {
+  data: {
+    add: (doc: unknown) => typeof Async;
+    get: (id: string) => typeof Async;
+    update: (id: string, doc: unknown) => typeof Async;
+  };
+}
+
+const { of, ask, lift } = ReaderT(Async);
+
+// @ts-ignore allow any type
+const validate = (schema) =>
+  (doc: unknown) => {
+    const { success, data, errors } = schema.safeParse(doc);
+    return success
+      ? Async.Resolved(data)
+      : Async.Rejected({ ok: false, msg: "ERROR: Invalid document", errors });
+  };
+
+const doUpsert = (hyper: H, doc: unknown) =>
+  (env: Config) =>
+    Async.of(doc)
+      .chain(ifElse(
+        () => isNil(env.schema),
+        Async.Resolved,
+        validate(prop("schema", env)),
+      ))
+      .chain((doc: unknown) =>
+        compose(hyper.data.get, prop("_id"))(doc)
+          .bichain(
+            () => hyper.data.add(doc),
+            (old: unknown) =>
+              hyper.data.update(prop("_id", old), mergeRight(old, doc)),
+          )
+      );
+
+export const upsert = (hyper: H) =>
+  (id: string, doc: unknown) =>
+    of(mergeRight(doc, { _id: id }))
+      .chain((doc: unknown) => ask(doUpsert(hyper, doc)).chain(lift));

--- a/src/actions/upsert_test.ts
+++ b/src/actions/upsert_test.ts
@@ -1,0 +1,52 @@
+import { assertEquals } from "asserts";
+import { upsert } from "./upsert.ts";
+import { Async } from "crocks";
+import { z } from "zod";
+
+const hyperAsync = {
+  data: {
+    add: () => Async.Resolved({ ok: false }),
+    update: () => Async.Resolved({ ok: true }),
+    get: () =>
+      Async.Resolved({ _id: "1", name: "Tom Wilson", type: "contact" }),
+  },
+};
+
+const doc = { _id: "contact-1", type: "contact", name: "Tom Wilson" };
+const schema = z.object({
+  _id: z.string(),
+  type: z.literal("contact"),
+  name: z.string(),
+});
+
+Deno.test("add document with schema", async () => {
+  const result = await upsert(hyperAsync)(doc._id, doc).runWith({
+    name: "contact",
+    schema,
+  }).toPromise();
+  assertEquals(result.ok, true);
+});
+
+Deno.test("add document without schema", async () => {
+  const result = await upsert(hyperAsync)(doc._id, doc).runWith({
+    name: "contact",
+  })
+    .toPromise();
+  assertEquals(result.ok, true);
+});
+
+Deno.test("add document if does not exist", async () => {
+  const hyper = {
+    data: {
+      add: () => Async.Resolved({ ok: true }),
+      update: () => Async.Resolved({ ok: false }),
+      get: () => Async.Rejected({ ok: false }),
+    },
+  };
+  const result = await upsert(hyper)(doc._id, doc).runWith({
+    name: "content",
+    schema,
+  })
+    .toPromise();
+  assertEquals(result.ok, true);
+});

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,7 @@
 import { mergeDeepRight } from "ramda";
 import { asyncify } from "./asyncify.ts";
 import { get } from "./actions/get.ts";
+import { remove } from "./actions/remove.ts";
 
 export const model = (hyper: unknown) => {
   const hyperAsync = asyncify(hyper);
@@ -13,7 +14,8 @@ export const model = (hyper: unknown) => {
             upsert: noop,
             get: (id: string) =>
               get(hyperAsync)(id).runWith(config).toPromise(),
-            remove: noop,
+            remove: (id: string) =>
+              remove(hyperAsync)(id).runWith(config).toPromise(),
             query: noop,
             search: noop,
             count: noop,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -3,6 +3,7 @@ import { asyncify } from "./asyncify.ts";
 import { get } from "./actions/get.ts";
 import { remove } from "./actions/remove.ts";
 import { upsert } from "./actions/upsert.ts";
+import { query } from "./actions/query.ts";
 
 export const model = (hyper: unknown) => {
   const hyperAsync = asyncify(hyper);
@@ -18,7 +19,8 @@ export const model = (hyper: unknown) => {
               get(hyperAsync)(id).runWith(config).toPromise(),
             remove: (id: string) =>
               remove(hyperAsync)(id).runWith(config).toPromise(),
-            query: noop,
+            query: (selector: unknown, options?: unknown) =>
+              query(hyperAsync)(selector, options).runWith(config).toPromise(),
             search: noop,
             count: noop,
             sync: noop,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -2,6 +2,7 @@ import { mergeDeepRight } from "ramda";
 import { asyncify } from "./asyncify.ts";
 import { get } from "./actions/get.ts";
 import { remove } from "./actions/remove.ts";
+import { upsert } from "./actions/upsert.ts";
 
 export const model = (hyper: unknown) => {
   const hyperAsync = asyncify(hyper);
@@ -11,7 +12,8 @@ export const model = (hyper: unknown) => {
       ext: {
         model(config: unknown) {
           return Object.freeze({
-            upsert: noop,
+            upsert: (id: string, doc: unknown) =>
+              upsert(hyperAsync)(id, doc).runWith(config).toPromise(),
             get: (id: string) =>
               get(hyperAsync)(id).runWith(config).toPromise(),
             remove: (id: string) =>

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -4,6 +4,7 @@ import { get } from "./actions/get.ts";
 import { remove } from "./actions/remove.ts";
 import { upsert } from "./actions/upsert.ts";
 import { query } from "./actions/query.ts";
+import type { Config } from "./types.ts";
 
 export const model = (hyper: unknown) => {
   const hyperAsync = asyncify(hyper);
@@ -11,7 +12,7 @@ export const model = (hyper: unknown) => {
     hyper,
     {
       ext: {
-        model(config: unknown) {
+        model(config: Config) {
           return Object.freeze({
             upsert: (id: string, doc: unknown) =>
               upsert(hyperAsync)(id, doc).runWith(config).toPromise(),

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -17,6 +17,7 @@ const hyper = model({
     get: () => Promise.resolve({ _id: "1", username: "rakis" }),
     update: () => Promise.resolve({ ok: true }),
     remove: () => Promise.resolve({ ok: true }),
+    query: () => Promise.resolve({ ok: true, docs: [] }),
   },
   cache: {
     remove: () => Promise.resolve({ ok: true }),
@@ -46,8 +47,8 @@ Deno.test("remove document successfully", async () => {
 
 Deno.test("query document successfully", async () => {
   const result = await profiles.query({ group: "admin" }, { limit: 10 });
-  assertEquals(result.ok, false);
-  assertEquals(result.msg, "Not Implemented!");
+  assertEquals(result.ok, true);
+  assertEquals(result.docs.length, 0);
 });
 
 Deno.test("search document successfully", async () => {

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -13,6 +13,13 @@ Deno.test("ok", () => {
 const hyper = model({
   data: {
     get: () => Promise.resolve({ _id: "1" }),
+    remove: () => Promise.resolve({ ok: true }),
+  },
+  cache: {
+    remove: () => Promise.resolve({ ok: true }),
+  },
+  search: {
+    remove: () => Promise.resolve({ ok: true }),
   },
 });
 const profiles = hyper.ext.model({ cache: false, schema });
@@ -31,8 +38,7 @@ Deno.test("get document successfully", async () => {
 
 Deno.test("remove document successfully", async () => {
   const result = await profiles.remove("1");
-  assertEquals(result.ok, false);
-  assertEquals(result.msg, "Not Implemented!");
+  assertEquals(result.ok, true);
 });
 
 Deno.test("query document successfully", async () => {

--- a/src/mod_test.ts
+++ b/src/mod_test.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 const schema = z.object({
   _id: z.string(),
+  username: z.string(),
 });
 
 Deno.test("ok", () => {
@@ -12,7 +13,9 @@ Deno.test("ok", () => {
 
 const hyper = model({
   data: {
-    get: () => Promise.resolve({ _id: "1" }),
+    add: () => Promise.resolve({ ok: true }),
+    get: () => Promise.resolve({ _id: "1", username: "rakis" }),
+    update: () => Promise.resolve({ ok: true }),
     remove: () => Promise.resolve({ ok: true }),
   },
   cache: {
@@ -22,12 +25,12 @@ const hyper = model({
     remove: () => Promise.resolve({ ok: true }),
   },
 });
-const profiles = hyper.ext.model({ cache: false, schema });
+const profiles = hyper.ext.model({ name: "profile", cache: false, schema });
 
 Deno.test("upsert document successfully", async () => {
-  const result = await profiles.upsert("1", { username: "rakis" });
-  assertEquals(result.ok, false);
-  assertEquals(result.msg, "Not Implemented!");
+  const result = await profiles.upsert("1", { _id: "1", username: "rakis" });
+  assertEquals(result.ok, true);
+  //assertEquals(result.msg, "Not Implemented!");
 });
 
 Deno.test("get document successfully", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+//import { z } from 'zod'
+
+// model configuration flags
+export interface Config {
+  schema: unknown;
+  log: boolean;
+  /*
+  cache: boolean;
+  search: string[];
+  */
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 
 // model configuration flags
 export interface Config {
+  name: string;
   schema: unknown;
   log: boolean;
   /*


### PR DESCRIPTION
In this PR, we are shipping the core components of the `hyper-model` module, that takes an optional schema and uses it to validate the documents as they are upserted, removed and returned via get command. Also a basic pass through for the query function.

This will set the ground work for the future enhancements of composition.